### PR TITLE
do not surround first key with brackets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ test/dummy/tmp/
 test/dummy/.sass-cache
 .idea/
 Gemfile.lock
+node_modules/

--- a/app/assets/javascripts/try_api/application.js.erb
+++ b/app/assets/javascripts/try_api/application.js.erb
@@ -204,7 +204,7 @@ TryApiApp.controller('HomeController', [
       if (next == null) {
         next = '';
       }
-      if (next) {
+      if (path && next) {
         next = '[' + next + ']';
       }
       if (path) {


### PR DESCRIPTION
## Description

It seems that due to an oversight in the `try_api` form key builder, the first argument is always wrapped in brackets, so `user[id]` becomes `[user][id]`.  This pull request removes the wrapping of the first key, restoring compatibility with newer Rails versions. This change should not affect previous versions, as the updated behavior was expected.

## Background

In a recent Rails version (somewhere between `7.1.4` and `7.1.4.2`), the way form arguments are parsed was changed. Specifically, if the first part of a key is surrounded by brackets (e.g., `[user][id]` or `[user_id]`), it will be parsed as-is instead of being lifted as before.

For example, form data with a key named `[user][id]` will be parsed as `{"[user]": { "id": 1 }}` instead of `{"user": { "id": 1 }}`.